### PR TITLE
Implement CRUD Operations for Tasks Resource

### DIFF
--- a/app/Enums/TaskStatus.php
+++ b/app/Enums/TaskStatus.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Enums;
+
+use App\Enums\Traits\ToArrayEnum;
+
+enum TaskStatus: string
+{
+    use ToArrayEnum;
+
+    case NOTSTARTED = 'not started';
+    case INPROGRESS = 'in progress';
+    case ONHOLD = 'on hold';
+    case COMPLETED = 'completed';
+    case DELAYED = 'delayed';
+    case BLOCKED = 'blocked';
+    case CANCELLED = 'cancelled';
+    case NEEDSREVIEW = 'needs review';
+    case HIGHPRIORITY = 'high priority';
+    case LOWPRIORITY = 'low priority';
+}

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreTaskRequest;
+use App\Http\Requests\UpdateTaskRequest;
+use App\Models\Project;
+use App\Models\Task;
+use Illuminate\Http\Request;
+
+class TaskController extends Controller
+{
+    public function __construct()
+    {
+        $this->authorizeResource(Task::class, 'task');
+    }
+
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(Request $request)
+    {
+        return view('tasks.index', [
+            'items' => Task::search($request->input('query') ?? '')->paginate(10),
+            'resourceName' => 'tasks',
+        ]);
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        return view('tasks.create', [
+            'projects' => Project::orderBy('title')->select('title', 'id')->get(),
+        ]);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(StoreTaskRequest $request)
+    {
+        $validated = $request->validated();
+
+        $task = Task::create($validated);
+
+        return redirect()->route('tasks.show', $task);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Task $task)
+    {
+        return view('tasks.show', [
+            'task' => $task
+        ]);
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(Task $task)
+    {
+        return view('tasks.edit', [
+            'task' => $task,
+            'projects' => Project::orderBy('title')->select('title', 'id')->get(),
+        ]);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(UpdateTaskRequest $request, Task $task)
+    {
+        $validated = $request->validated();
+
+        if (! empty($validated)) {
+            $task->update($validated);
+        }
+
+        return redirect()->route('tasks.show', $task);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Task $task)
+    {
+        $task->delete();
+
+        return redirect()->route('tasks.index');
+    }
+}

--- a/app/Http/Requests/StoreTaskRequest.php
+++ b/app/Http/Requests/StoreTaskRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Enums\TaskStatus;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreTaskRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'description' => ['required', 'string'],
+            'due_date' => ['required', 'date_format:Y-m-d'],
+            'status' => ['required', 'string', Rule::enum(TaskStatus::class)],
+            'project_id' => ['required', 'integer', 'exists:projects,id'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateTaskRequest.php
+++ b/app/Http/Requests/UpdateTaskRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Enums\TaskStatus;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateTaskRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $task = $this->route('task');
+
+        return [
+            'title' => ['exclude_if:title,' . $task->title, 'required', 'string', 'max:255'],
+            'description' => ['exclude_if:description,' . $task->description, 'required', 'string'],
+            'due_date' => ['exclude_if:due_date,' . $task->due_date, 'required', 'date_format:Y-m-d'],
+            'project_id' => ['exclude_if:project_id,' . $task->project_id, 'required', 'integer', 'exists:projects,id'],
+            'status' => ['exclude_if:status,' . $task->status, 'required', 'string', Rule::enum(TaskStatus::class)],
+        ];
+    }
+}

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -5,15 +5,24 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Laravel\Scout\Searchable;
 
 class Task extends Model
 {
-    use HasFactory;
+    use HasFactory, Searchable;
 
     protected $fillable = ['title', 'description', 'due_date', 'status', 'project_id'];
 
     public function project(): BelongsTo
     {
         return $this->belongsTo(Project::class);
+    }
+
+    public function toSearchableArray()
+    {
+        return [
+            'title' => $this->title,
+            'description' => $this->description
+        ];
     }
 }

--- a/app/Policies/TaskPolicy.php
+++ b/app/Policies/TaskPolicy.php
@@ -14,7 +14,7 @@ class TaskPolicy
      */
     public function viewAny(User $user): bool
     {
-        return $user->can(TaskPermissionsEnum::READ_TASKS);
+        return $user->can(TaskPermissionsEnum::READ_TASKS->value);
     }
 
     /**
@@ -22,7 +22,7 @@ class TaskPolicy
      */
     public function view(User $user, Task $task): bool
     {
-        return $user->can(TaskPermissionsEnum::READ_TASKS);
+        return $user->can(TaskPermissionsEnum::READ_TASKS->value);
     }
 
     /**
@@ -30,7 +30,7 @@ class TaskPolicy
      */
     public function create(User $user): bool
     {
-        return $user->can(TaskPermissionsEnum::CREATE_TASKS);
+        return $user->can(TaskPermissionsEnum::CREATE_TASKS->value);
     }
 
     /**
@@ -38,7 +38,7 @@ class TaskPolicy
      */
     public function update(User $user, Task $task): bool
     {
-        return $user->can(TaskPermissionsEnum::UPDATE_TASKS);
+        return $user->can(TaskPermissionsEnum::UPDATE_TASKS->value);
     }
 
     /**
@@ -46,7 +46,7 @@ class TaskPolicy
      */
     public function delete(User $user, Task $task): bool
     {
-        return $user->can(TaskPermissionsEnum::DELETE_TASKS);
+        return $user->can(TaskPermissionsEnum::DELETE_TASKS->value);
     }
 
     /**

--- a/database/factories/TaskFactory.php
+++ b/database/factories/TaskFactory.php
@@ -19,7 +19,7 @@ class TaskFactory extends Factory
         return [
             'title' => fake()->word(),
             'description' => fake()->text(),
-            'due_date' => fake()->dateTimeBetween('+1 day', '+1 week'),
+            'due_date' => fake()->dateTimeBetween('+1 day', '+1 week')->format('Y-m-d'),
             'status' => fake()->randomElement([
                 "Not Started",
                 "In Progress",

--- a/database/factories/TaskFactory.php
+++ b/database/factories/TaskFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\TaskStatus;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -20,18 +21,7 @@ class TaskFactory extends Factory
             'title' => fake()->word(),
             'description' => fake()->text(),
             'due_date' => fake()->dateTimeBetween('+1 day', '+1 week')->format('Y-m-d'),
-            'status' => fake()->randomElement([
-                "Not Started",
-                "In Progress",
-                "On Hold",
-                "Completed",
-                "Delayed",
-                "Blocked",
-                "Cancelled",
-                "Needs Review",
-                "High Priority",
-                "Low Priority",
-            ]),
+            'status' => fake()->randomElement(TaskStatus::toArray()),
         ];
     }
 }

--- a/resources/views/tasks/create.blade.php
+++ b/resources/views/tasks/create.blade.php
@@ -1,0 +1,106 @@
+@extends('layouts.app');
+
+@section('content')
+    @parent
+    <x-content>
+        <h2 class="text-4xl font-bold dark:text-white mb-5 ml-1">Create Task</h2>
+        <form class="px-2" method="POST" action="/tasks">
+            @csrf
+            <div class="mb-6">
+                <label for="title" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Title</label>
+                <input type="text" id="title" name="title" size="255"
+                    class="bg-gray-50 border text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500
+                    @error('title')
+                        border-red-500
+                    @else
+                        border-gray-300
+                    @enderror"
+                    placeholder="Customer Relationship Management" value="{{ old('title') }}" required>
+                @error('title')
+                    <p id="filled_error_help" class="mt-2 text-xs text-red-600 dark:text-red-400">
+                        {{ $message }}
+                    </p>
+                @enderror
+            </div>
+            <div class="mb-6">
+                <label for="description"
+                    class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Description</label>
+                <textarea id="description" rows="4" name="description"
+                    class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500
+                @error('description')
+                    border-red-500
+                @else
+                    border-gray-300
+                @enderror"
+                    placeholder="Write the description of the project here..." required>{{ old('description') }}</textarea>
+                @error('description')
+                    <p id="filled_error_help" class="mt-2 text-xs text-red-600 dark:text-red-400">
+                        {{ $message }}
+                    </p>
+                @enderror
+            </div>
+            <div class="mb-6">
+                <label for="due_date" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Due Date</label>
+                <div class="relative max-w-sm">
+                    <div class="absolute inset-y-0 start-0 flex items-center ps-3.5 pointer-events-none">
+                        <svg class="w-4 h-4 text-gray-500 dark:text-gray-400" aria-hidden="true"
+                            xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                            <path
+                                d="M20 4a2 2 0 0 0-2-2h-2V1a1 1 0 0 0-2 0v1h-3V1a1 1 0 0 0-2 0v1H6V1a1 1 0 0 0-2 0v1H2a2 2 0 0 0-2 2v2h20V4ZM0 18a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8H0v10Zm5-8h10a1 1 0 0 1 0 2H5a1 1 0 0 1 0-2Z" />
+                        </svg>
+                    </div>
+                    <input datepicker type="text" name="due_date"
+                        id="due_date"
+                        value="{{ old('due_date') }}"
+                        autocomplete="off"
+                        class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full ps-10 p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+                        datepicker-format="yyyy-mm-dd" placeholder="Select due date" required>
+                    </div>
+                    @error('due_date')
+                        <p id="filled_error_help" class="mt-2 text-xs text-red-600 dark:text-red-400">
+                            {{ $message }}
+                        </p>
+                    @enderror
+            </div>
+
+            <div class="mb-6">
+                <label for="status" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Status</label>
+                <select id="status" name="status" required
+                    class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
+                    <option value="" selected disabled>Choose a status</option>
+                    @foreach (\App\Enums\TaskStatus::toArray() as $status)
+                        <option value="{{ $status }}">
+                            {{ ucfirst($status) }}
+                        </option>
+                    @endforeach
+                </select>
+                @error('status')
+                    <p id="filled_error_help" class="mt-2 text-xs text-red-600 dark:text-red-400">
+                        {{ $message }}
+                    </p>
+                @enderror
+            </div>
+
+            <div class="mb-6">
+                <label for="project" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Project</label>
+                <select id="project" name="project_id" required
+                    class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
+                    <option value="" selected disabled>Choose a project</option>
+                    @foreach ($projects as $project)
+                        <option value="{{ $project->id }}">
+                            {{ $project->title }}
+                        </option>
+                    @endforeach
+                </select>
+                @error('project_id')
+                    <p id="filled_error_help" class="mt-2 text-xs text-red-600 dark:text-red-400">
+                        {{ $message }}
+                    </p>
+                @enderror
+            </div>
+
+            <button type="submit"
+                class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm w-full sm:w-auto px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">Submit</button>
+        </form>
+    </x-content>
+@endsection

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -1,0 +1,107 @@
+@extends('layouts.app');
+
+@section('content')
+    @parent
+    <x-content>
+        <h2 class="text-4xl font-bold dark:text-white mb-5 ml-1">Edit Task</h2>
+        <form class="px-2" method="POST" action="/tasks/{{ $task->id }}">
+            @csrf
+            @method('PATCH')
+            <div class="mb-6">
+                <label for="title" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Title</label>
+                <input type="text" id="title" name="title" size="255"
+                    class="bg-gray-50 border text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500
+                    @error('title')
+                        border-red-500
+                    @else
+                        border-gray-300
+                    @enderror"
+                    placeholder="Customer Relationship Management" value="{{ old('title') ?? $task->title }}" required>
+                @error('title')
+                    <p id="filled_error_help" class="mt-2 text-xs text-red-600 dark:text-red-400">
+                        {{ $message }}
+                    </p>
+                @enderror
+            </div>
+            <div class="mb-6">
+                <label for="description"
+                    class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Description</label>
+                <textarea id="description" rows="4" name="description"
+                    class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500
+                @error('description')
+                    border-red-500
+                @else
+                    border-gray-300
+                @enderror"
+                    placeholder="Write the description of the project here..." required>{{ old('description') ?? $task->description }}</textarea>
+                @error('description')
+                    <p id="filled_error_help" class="mt-2 text-xs text-red-600 dark:text-red-400">
+                        {{ $message }}
+                    </p>
+                @enderror
+            </div>
+            <div class="mb-6">
+                <label for="due_date" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Due Date</label>
+                <div class="relative max-w-sm">
+                    <div class="absolute inset-y-0 start-0 flex items-center ps-3.5 pointer-events-none">
+                        <svg class="w-4 h-4 text-gray-500 dark:text-gray-400" aria-hidden="true"
+                            xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                            <path
+                                d="M20 4a2 2 0 0 0-2-2h-2V1a1 1 0 0 0-2 0v1h-3V1a1 1 0 0 0-2 0v1H6V1a1 1 0 0 0-2 0v1H2a2 2 0 0 0-2 2v2h20V4ZM0 18a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8H0v10Zm5-8h10a1 1 0 0 1 0 2H5a1 1 0 0 1 0-2Z" />
+                        </svg>
+                    </div>
+                    <input datepicker type="text" name="due_date"
+                        id="due_date"
+                        value="{{ old('due_date') ?? $task->due_date }}}}}"
+                        autocomplete="off"
+                        class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full ps-10 p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+                        datepicker-format="yyyy-mm-dd" placeholder="Select due date" required>
+                    </div>
+                    @error('due_date')
+                        <p id="filled_error_help" class="mt-2 text-xs text-red-600 dark:text-red-400">
+                            {{ $message }}
+                        </p>
+                    @enderror
+            </div>
+
+            <div class="mb-6">
+                <label for="status" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Status</label>
+                <select id="status" name="status" required
+                    class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
+                    <option value="" selected disabled>Choose a status</option>
+                    @foreach (\App\Enums\TaskStatus::toArray() as $status)
+                        <option value="{{ $status }}" {{ $task->status == $status ? 'selected' : ''}}>
+                            {{ ucfirst($status) }}
+                        </option>
+                    @endforeach
+                </select>
+                @error('status')
+                    <p id="filled_error_help" class="mt-2 text-xs text-red-600 dark:text-red-400">
+                        {{ $message }}
+                    </p>
+                @enderror
+            </div>
+
+            <div class="mb-6">
+                <label for="project" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Project</label>
+                <select id="project" name="project_id" required
+                    class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
+                   <option value="" selected disabled>Choose a project</option>
+                    @foreach ($projects as $project)
+                        <option value="{{ $project->id }}" {{ $task->project_id == $project->id ? 'selected' : ''}}>
+                            {{ $project->title }}
+                        </option>
+                    @endforeach
+                </select>
+                @error('project_id')
+                    <p id="filled_error_help" class="mt-2 text-xs text-red-600 dark:text-red-400">
+                        {{ $message }}
+                    </p>
+                @enderror
+            </div>
+
+            <button type="submit"
+                class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm w-full sm:w-auto px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">Submit</button>
+        </form>
+    </x-content>
+@endsection

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -1,0 +1,43 @@
+@extends('layouts.app');
+
+@section('content')
+    @parent
+    <x-table :columnHeaders="['title', 'description', 'due date', 'status', 'created at', 'project']" :$items :$resourceName>
+        @foreach ($items as $item)
+            <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600">
+                <td scope="row" class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white">
+                    {{ $item->title }}
+                </td>
+                <td scope="row" class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white">
+                    {{ $item->description}}
+                </td>
+                <td scope="row" class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white">
+                    {{ $item->due_date }}
+                </td>
+                <td scope="row" class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white">
+                    {{ $item->status }}
+                </td>
+                <td scope="row" class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white">
+                    {{ $item->created_at->diffForHumans() }}
+                </td>
+                <td scope="row" class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white">
+                    <a href="/projects/{{ $item->project->id }}">
+                        {{ $item->project->title }}
+                    </a>
+                </td>
+                <td class="flex items-center px-6 py-4">
+                    <a href="/{{ $resourceName }}/{{ $item->id }}"
+                        class="font-medium text-blue-600 dark:text-blue-500 hover:underline">View</a>
+                    <a href="/{{ $resourceName }}/{{ $item->id }}/edit"
+                        class="font-medium text-blue-600 dark:text-blue-500 hover:underline ms-3">Edit</a>
+                    <form class="inline mb-0" method="POST" action="/{{ $resourceName }}/{{ $item->id }}">
+                        @csrf
+                        @method('delete')
+                        <button type="submit"
+                            class="font-medium text-red-600 dark:text-red-500 hover:underline ms-3">Delete</button>
+                    </form>
+                </td>
+                <tr />
+        @endforeach
+    </x-table>
+@endsection

--- a/resources/views/tasks/show.blade.php
+++ b/resources/views/tasks/show.blade.php
@@ -1,0 +1,46 @@
+@extends('layouts.app');
+
+@section('content')
+    @parent
+    <x-content>
+        <div class="container mx-auto px-6 py-8 shadow-md">
+            <h2 class="text-4xl font-bold dark:text-white mb-2">
+                {{ $task->title }}
+            </h2>
+            <dl class="max-w-md text-gray-900 divide-y divide-gray-200 dark:text-white dark:divide-gray-700">
+                <div class="flex flex-col pb-3">
+                    <dt class="mb-1 text-gray-500 md:text-lg dark:text-gray-400">Description</dt>
+                    <dd class="text-lg font-semibold">
+                        {!! nl2br(e($task->description)) !!}
+                    </dd>
+                </div>
+                <div class="flex flex-col py-3">
+                    <dt class="mb-1 text-gray-500 md:text-lg dark:text-gray-400">Due Date</dt>
+                    <dd class="text-lg font-semibold">
+                        {{ $task->due_date }}
+                    </dd>
+                </div>
+                <div class="flex flex-col py-3">
+                    <dt class="mb-1 text-gray-500 md:text-lg dark:text-gray-400">Status</dt>
+                    <dd class="text-lg font-semibold">
+                        {{ ucfirst($task->status) }}
+                    </dd>
+                </div>
+                <div class="flex flex-col py-3">
+                    <dt class="mb-1 text-gray-500 md:text-lg dark:text-gray-400">Created at</dt>
+                    <dd class="text-lg font-semibold">
+                        {{ ucfirst($task->created_at->diffForHumans() ) }}
+                    </dd>
+                </div>
+                <div class="flex flex-col py-3">
+                    <dt class="mb-1 text-gray-500 md:text-lg dark:text-gray-400">Project</dt>
+                    <dd class="text-lg font-semibold">
+                        <a href="/projects/{{ $task->project->id }}">
+                            {{ $task->project->title }}
+                        </a>
+                    </dd>
+                </div>
+            </dl>
+        </div>
+    </x-content>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\ClientController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ProjectController;
+use App\Http\Controllers\TaskController;
 use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
 
@@ -26,5 +27,7 @@ Route::resource('users', UserController::class)->middleware(['auth', 'verified']
 Route::resource('clients', ClientController::class)->middleware(['auth', 'verified']);
 
 Route::resource('projects', ProjectController::class)->middleware(['auth', 'verified']);
+
+Route::resource('tasks', TaskController::class)->middleware(['auth', 'verified']);
 
 require __DIR__.'/auth.php';

--- a/tests/Feature/TaskControllerTest.php
+++ b/tests/Feature/TaskControllerTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\RolesEnum;
+use App\Enums\TaskStatus;
+use App\Models\Client;
+use App\Models\Project;
+use App\Models\Task;
+use App\Models\User;
+use Database\Seeders\RolesAndPermissionsSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Spatie\Permission\Contracts\Role;
+use Tests\TestCase;
+
+class TaskControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $seeder = RolesAndPermissionsSeeder::class;
+
+    public function test_index_with_query()
+    {
+        $user = User::factory()->create()->assignRole(RolesEnum::ADMINISTRATOR);
+
+        $project = Project::factory()->create(['user_id' => $user->id]);
+
+        $task1 = Task::factory()->create(['title' => 'Test Task 1', 'project_id' => $project->id]);
+        $task2 = Task::factory()->create(['title' => 'Test Task 2', 'project_id' => $project->id]);
+
+        $response = $this->actingAs($user)->get(route('tasks.index', ['query' => 'Test Task 1']));
+
+        $response->assertStatus(200);
+        $response->assertViewHas('items');
+        $response->assertViewHas('resourceName', 'tasks');
+        $this->assertTrue($response->viewData('items')->contains($task1));
+        $this->assertFalse($response->viewData('items')->contains($task2));
+    }
+
+    public function test_index_without_query()
+    {
+        $user = User::factory()->create()->assignRole(RolesEnum::ADMINISTRATOR);
+
+        $project = Project::factory()->create(['user_id' => $user->id]);
+
+        $task1 = Task::factory()->create(['title' => 'Test Task 1', 'project_id' => $project->id]);
+        $task2 = Task::factory()->create(['title' => 'Test Task 2', 'project_id' => $project->id]);
+
+        $response = $this->actingAs($user)->get(route('tasks.index'));
+
+        $response->assertStatus(200);
+        $response->assertViewHas('items');
+        $response->assertViewHas('resourceName', 'tasks');
+        $this->assertTrue($response->viewData('items')->contains($task1));
+        $this->assertTrue($response->viewData('items')->contains($task2));
+    }
+
+    public function test_create()
+    {
+        $user = User::factory()->create()->assignRole(RolesEnum::ADMINISTRATOR);
+        $project = Project::factory()->create(['user_id' => $user->id]);
+
+        $response = $this->actingAs($user)->get(route('tasks.create'));
+
+        $response->assertStatus(200);
+        $response->assertViewHas('projects');
+    }
+
+    public function test_store()
+    {
+        $user = User::factory()->create()->assignRole(RolesEnum::ADMINISTRATOR);
+        $project = Project::factory()->create(['user_id' => $user->id]);
+
+        $taskData = Task::factory()->make([
+            'project_id' => $project->id,
+        ])->toArray();
+
+        $response = $this->actingAs($user)->post(route('tasks.store'), $taskData);
+
+        $createdTask = Task::latest('id')->first();
+
+        $response->assertRedirect(route('tasks.show', $createdTask));
+        $this->assertDatabaseHas('tasks', $taskData);
+    }
+
+    public function test_show()
+    {
+        $user = User::factory()->create()->assignRole(RolesEnum::ADMINISTRATOR);
+        $project = Project::factory()->create(['user_id' => $user->id]);
+
+        $task = Task::factory()->create(['project_id' => $project->id]);
+
+        $response = $this->actingAs($user)->get(route('tasks.show', $task));
+
+        $response->assertStatus(200);
+        $response->assertViewHas('task');
+    }
+
+    public function test_edit()
+    {
+        $user = User::factory()->create()->assignRole(RolesEnum::ADMINISTRATOR);
+        $project = Project::factory()->create(['user_id' => $user->id]);
+
+        $task = Task::factory()->create(['project_id' => $project->id]);
+
+        $response = $this->actingAs($user)->get(route('tasks.edit', $task));
+
+        $response->assertStatus(200);
+        $response->assertViewHas('task');
+        $response->assertViewHas('projects');
+    }
+
+    public function test_update()
+    {
+        $user = User::factory()->create()->assignRole(RolesEnum::ADMINISTRATOR);
+        $project = Project::factory()->create(['user_id' => $user->id]);
+        $task = Task::factory()->create(['project_id' => $project->id]);
+
+        $updatedData = [
+            ...$task->toArray(),
+            'title' => 'Updated Task Name',
+        ];
+
+        $response = $this->actingAs($user)->put(route('tasks.update', $task), $updatedData);
+
+        $response->assertRedirect(route('tasks.show', $task));
+        $this->assertDatabaseHas('tasks', $updatedData);
+    }
+
+    public function test_destroy()
+    {
+        $user = User::factory()->create()->assignRole(RolesEnum::ADMINISTRATOR);
+        $project = Project::factory()->create(['user_id' => $user->id]);
+        $task = Task::factory()->create(['project_id' => $project->id]);
+
+        $response = $this->actingAs($user)->delete(route('tasks.destroy', $task));
+
+        $response->assertRedirect(route('tasks.index'));
+        $this->assertModelMissing($task);
+    }
+}


### PR DESCRIPTION
Issue Reference: #4 

### Overview
This pull request addresses the task of implementing a new resource route for tasks in the CRM, allowing for CRUD operations.

### Changes Made
- Added a new resource route for `tasks` in `routes/web.php`.
- Created the `TaskController` with methods for `index`, `create`, `store`, `show`, `edit`, `update`, and `destroy`.
- Implemented functionality for displaying a paginated list, creating, storing, showing, editing, updating, and deleting tasks.
- Added authentication and authorization checks to ensure security.
- Applied styling to match the CRM's design.

### Context
This enhancement provides a comprehensive set of tools for efficient task management within the CRM.

### Acceptance Criteria
- The `/tasks` route displays a paginated list of tasks.
- The `/tasks/create` route allows the creation of a new task.
- The `/tasks/{task}` route shows detailed information about a specific task.
- The `/tasks/{task}/edit` route allows for editing an existing task.
- The `store`, `update`, and `destroy` methods handle data storage, updating, and deletion respectively.

### Example Usage
```php
// routes/web.php

use App\Http\Controllers\TaskController;

Route::resource('tasks', TaskController::class);
```