### PR TITLE
test(infra): set up robust Docker testing environment with Playwright

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,36 @@
+# Test image — identical to the dev Dockerfile but uses entrypoint.test.sh
+FROM php:8.2-fpm
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    libpng-dev \
+    libonig-dev \
+    libxml2-dev \
+    zip \
+    unzip \
+    nodejs \
+    npm
+
+# Clear cache
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install PHP extensions required by Laravel
+RUN docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath gd
+
+# Get latest Composer
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+# Set working directory
+WORKDIR /var/www
+
+# Copy test entrypoint script
+COPY docker/entrypoint.test.sh /usr/local/bin/entrypoint.test.sh
+RUN chmod +x /usr/local/bin/entrypoint.test.sh
+
+# Use test entrypoint
+ENTRYPOINT ["entrypoint.test.sh"]
+
+# Default command
+CMD ["php-fpm"]

--- a/README.md
+++ b/README.md
@@ -299,24 +299,30 @@ The application features a sophisticated multi-tenant database architecture with
 
 ## **Testing**
 
-The project includes unit and feature tests to ensure code quality and reliability.
+The project includes a comprehensive testing suite comprising PHPUnit (Unit/Feature) and Playwright (E2E) tests, all executed within a dedicated Docker environment.
 
-To run tests:
+To run the tests:
 
-1. Set up the testing environment:
+1. **Ensure the test environment file exists**:
 ```sh
 cp .env.testing.example .env.testing
 ```
 
-2. Build assets:
+2. **Run tests using NPM commands** (these orchestrate the Docker containers automatically):
 ```sh
-npm run build
-```
+# Run the entire suite (PHPUnit + Playwright)
+npm run test:all
 
-3. Run the test suite:
-```sh
-php artisan test
+# Run backend tests only (PHPUnit)
+npm run test:unit
+
+# Run E2E tests only (Playwright)
+npm run test:e2e
+
+# Run Playwright in UI mode for debugging
+npm run test:e2e:ui
 ```
+*Note: These commands handle container startup, database migrations/seeding, and cleanup.*
 
 ## **Project Structure**
 ```

--- a/bin/test-all.sh
+++ b/bin/test-all.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMPOSE="docker compose -f $(dirname "$0")/../docker-compose.test.yml"
+
+trap "$COMPOSE down" EXIT INT TERM
+
+echo "🚀 Starting test stack..."
+$COMPOSE up -d --wait --remove-orphans app_test nginx_test db_test meilisearch_test
+
+echo "🧪 Running PHPUnit (unit + feature)..."
+$COMPOSE exec app_test php artisan test --env=testing
+
+echo "🌱 Re-seeding database for E2E tests..."
+$COMPOSE exec app_test php artisan migrate:fresh --seed --env=testing
+
+echo "🎭 Running Playwright E2E tests..."
+$COMPOSE run --rm playwright npx playwright test --reporter=list

--- a/bin/test-e2e-ui.sh
+++ b/bin/test-e2e-ui.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMPOSE="docker compose -f $(dirname "$0")/../docker-compose.test.yml"
+
+trap "$COMPOSE down" EXIT INT TERM
+
+echo "🚀 Starting test stack..."
+$COMPOSE up -d --wait --remove-orphans app_test nginx_test db_test meilisearch_test
+
+echo "🌱 Seeding database for Playwright UI..."
+$COMPOSE exec app_test php artisan migrate:fresh --seed --env=testing
+
+echo "🎭 Launching Playwright UI (http://localhost:8060)..."
+$COMPOSE run --rm --service-ports playwright \
+  npx playwright test --ui-host=0.0.0.0 --ui-port=8060

--- a/bin/test-e2e.sh
+++ b/bin/test-e2e.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMPOSE="docker compose -f $(dirname "$0")/../docker-compose.test.yml"
+
+trap "$COMPOSE down" EXIT INT TERM
+
+echo "🚀 Starting test stack..."
+$COMPOSE up -d --wait --remove-orphans app_test nginx_test db_test meilisearch_test
+
+echo "🌱 Seeding database for E2E tests..."
+$COMPOSE exec app_test php artisan migrate:fresh --seed --env=testing
+
+echo "🎭 Running Playwright E2E tests..."
+$COMPOSE run --rm playwright npx playwright test --reporter=list

--- a/bin/test-unit.sh
+++ b/bin/test-unit.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMPOSE="docker compose -f $(dirname "$0")/../docker-compose.test.yml"
+
+trap "$COMPOSE down" EXIT INT TERM
+
+echo "🚀 Starting test stack..."
+$COMPOSE up -d --wait --remove-orphans app_test db_test meilisearch_test
+
+echo "🧪 Running PHPUnit (unit + feature)..."
+$COMPOSE exec app_test php artisan test --env=testing

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,95 @@
+services:
+
+  # 1. PHP Application (Test)
+  app_test:
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+    container_name: nexus_app_test
+    restart: "no"
+    working_dir: /var/www
+    env_file:
+      - .env.testing
+    volumes:
+      - ./:/var/www:z
+    networks:
+      - nexus-test-network
+    depends_on:
+      db_test:
+        condition: service_healthy
+      meilisearch_test:
+        condition: service_started
+    healthcheck:
+      # Passes only after entrypoint.test.sh has finished migrate:fresh --seed
+      test: ["CMD", "test", "-f", "/tmp/.bootstrap_complete"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 10s
+
+  # 2. Web Server (Nginx) — Test
+  nginx_test:
+    image: nginx:alpine
+    container_name: nexus_nginx_test
+    restart: "no"
+    ports:
+      - "8001:80"
+    volumes:
+      - ./:/var/www:z
+      - ./docker/nginx/test.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      app_test:
+        condition: service_healthy
+    networks:
+      - nexus-test-network
+
+  # 3. Database — Test (ephemeral, no named volume)
+  db_test:
+    image: mysql:8.0
+    container_name: nexus_db_test
+    restart: "no"
+    environment:
+      MYSQL_DATABASE: nexus_test
+      MYSQL_ROOT_PASSWORD: nexus_password
+      MYSQL_PASSWORD: nexus_password
+      MYSQL_USER: nexus_user
+    # tmpfs keeps data in RAM — wiped on container stop
+    tmpfs:
+      - /var/lib/mysql:mode=777
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-u", "nexus_user", "-pnexus_password"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    networks:
+      - nexus-test-network
+
+  # 4. Meilisearch — Test (ephemeral)
+  meilisearch_test:
+    image: getmeili/meilisearch:latest
+    container_name: nexus_meilisearch_test
+    restart: "no"
+    environment:
+      MEILI_MASTER_KEY: masterKey
+      MEILI_NO_ANALYTICS: "true"
+    # No volume — indexes are discarded on container stop
+    networks:
+      - nexus-test-network
+
+  # 5. Playwright E2E Runner
+  playwright:
+    image: mcr.microsoft.com/playwright:v1.59.1-jammy
+    container_name: nexus_playwright_test
+    volumes:
+      - ./:/var/www:z
+    working_dir: /var/www
+    ports:
+      - "8060:8060"
+    networks:
+      - nexus-test-network
+    depends_on:
+      - nginx_test
+
+networks:
+  nexus-test-network:
+    driver: bridge

--- a/docker/entrypoint.test.sh
+++ b/docker/entrypoint.test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+echo "=== Test Entrypoint ==="
+
+# Install composer dependencies if vendor folder is missing
+if [ ! -d "vendor" ]; then
+    echo "Vendor directory not found. Installing dependencies..."
+    composer install --no-interaction --prefer-dist --optimize-autoloader
+fi
+
+# Wait for the test database to be ready
+echo "Waiting for db_test..."
+until php artisan db:monitor --databases=mysql --env=testing > /dev/null 2>&1; do
+  echo "  db_test is unavailable — retrying in 2s"
+  sleep 2
+done
+echo "  db_test is ready."
+
+# Run a fresh migration + seed on the test database (wipes + re-creates schema + seeds fixtures)
+echo "Running fresh migrations + seeds on nexus_test..."
+php artisan migrate:fresh --env=testing --force --no-interaction --seed
+
+# Sync Scout index settings against the test Meilisearch instance
+echo "Syncing Scout index settings (test)..."
+php artisan scout:sync-index-settings --env=testing
+
+echo "Bootstrap complete. Starting command..."
+
+# Signal that bootstrap is done (used by the Docker healthcheck)
+touch /tmp/.bootstrap_complete
+
+# Execute the main container command
+exec "$@"

--- a/docker/nginx/test.conf
+++ b/docker/nginx/test.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+    index index.php index.html;
+    server_name localhost;
+    root /var/www/public;
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass app_test:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
     "scripts": {
         "dev": "vite",
         "build": "vite build",
-        "test:e2e": "docker compose run --rm playwright npx playwright test --reporter=list",
-        "test:e2e:ui": "docker compose run --rm --service-ports playwright npx playwright test --ui-host=0.0.0.0 --ui-port=8060"
+        "test:unit": "bash bin/test-unit.sh",
+        "test:e2e": "bash bin/test-e2e.sh",
+        "test:e2e:ui": "bash bin/test-e2e-ui.sh",
+        "test:all": "bash bin/test-all.sh"
     },
     "devDependencies": {
         "@inertiajs/react": "^1.0.14",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,13 +22,18 @@
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
         <env name="DB_CONNECTION" value="mysql"/>
-        <env name="DB_HOST" value="db"/>
+        <env name="DB_HOST" value="db_test"/>
+        <env name="DB_PORT" value="3306"/>
         <env name="DB_DATABASE" value="nexus_test"/>
-        <env name="DB_USERNAME" value="nexus"/>
-        <env name="DB_PASSWORD" value="secret"/>
+        <env name="DB_USERNAME" value="nexus_user"/>
+        <env name="DB_PASSWORD" value="nexus_password"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
+        <env name="SCOUT_DRIVER" value="meilisearch"/>
+        <env name="SCOUT_QUEUE" value="false"/>
+        <env name="MEILISEARCH_HOST" value="http://meilisearch_test:7700"/>
+        <env name="MEILISEARCH_KEY" value="masterKey"/>
     </php>
 </phpunit>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://nginx',
+    baseURL: 'http://nginx_test',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -12,7 +12,7 @@
         <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
 
         <!-- Scripts -->
-        @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @vite(['resources/css/app.css', 'resources/js/app.tsx'])
     </head>
     <body class="font-sans text-gray-900 antialiased">
         <div class="min-h-screen flex flex-col sm:justify-center items-center pt-6 sm:pt-0 bg-gray-100">


### PR DESCRIPTION
Implement a dedicated Docker-based testing stack to ensure consistent test execution. This setup includes ephemeral database and search containers, automated bootstrapping with seeding, and shell scripts to orchestrate the full suite.

- Add `docker-compose.test.yml` and `Dockerfile.test` for isolation
- Implement `bin/` scripts to manage test lifecycle and DB re-seeding
- Update `package.json` with aliases for the new test scripts
- Correct Vite entry point in guest layout (`app.js` -> `app.tsx`)
- Align `phpunit.xml` and `playwright.config.ts` with Docker network
- Update documentation with the new testing workflow