### PR TITLE
Adapt configuration for Coolify deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,3 +63,6 @@ RUN mkdir -p \
 
 # Fix ownership
 RUN chown -R www-data:www-data /var/www/html
+
+# Switch back to the default unprivileged user
+USER www-data

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,4 @@ RUN mkdir -p \
     bootstrap/cache
 
 # Fix ownership
-USER root
 RUN chown -R www-data:www-data /var/www/html
-USER www-data

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ WORKDIR /var/www/html
 
 # Set environment variables for production
 ENV AUTORUN_ENABLED=true
+ENV AUTORUN_LARAVEL_MIGRATION=false
 ENV APP_ENV=production
 ENV APP_DEBUG=false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,9 @@ RUN npm run build
 # Stage 3: Final Production Image
 FROM serversideup/php:8.2-fpm-nginx AS final
 
+# Switch to root to perform administrative tasks during build
+USER root
+
 # Set working directory
 WORKDIR /var/www/html
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,53 @@
-# Use PHP 8.2 FPM (FastCGI Process Manager)
-FROM php:8.2-fpm
+# Stage 1: PHP Dependencies
+FROM composer:latest AS vendor
+WORKDIR /var/www/html
+COPY composer.json composer.lock ./
+RUN composer install \
+    --no-dev \
+    --no-interaction \
+    --no-plugins \
+    --no-scripts \
+    --prefer-dist
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y \
-    git \
-    curl \
-    libpng-dev \
-    libonig-dev \
-    libxml2-dev \
-    zip \
-    unzip \
-    nodejs \
-    npm
+# Stage 2: Frontend Assets
+FROM node:20 AS frontend
+WORKDIR /var/www/html
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
 
-# Clear cache
-RUN apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# Install PHP extensions required by Laravel
-RUN docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath gd
-
-# Get latest Composer
-COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+# Stage 3: Final Production Image
+FROM serversideup/php:8.2-fpm-nginx AS final
 
 # Set working directory
-WORKDIR /var/www
+WORKDIR /var/www/html
 
-# Copy entrypoint script
-COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
+# Set environment variables for production
+ENV AUTORUN_ENABLED=true
+ENV APP_ENV=production
+ENV APP_DEBUG=false
 
-# Use entrypoint script
-ENTRYPOINT ["entrypoint.sh"]
+# Copy PHP dependencies from Stage 1
+COPY --from=vendor /var/www/html/vendor ./vendor
 
-# Default command
-CMD ["php-fpm"]
+# Copy Frontend assets from Stage 2
+COPY --from=frontend /var/www/html/public/build ./public/build
+
+# Copy application code
+COPY . .
+
+# Ensure storage and bootstrap/cache are writable
+RUN mkdir -p \
+    storage/app/public \
+    storage/framework/cache \
+    storage/framework/sessions \
+    storage/framework/testing \
+    storage/framework/views \
+    storage/logs \
+    bootstrap/cache
+
+# Fix ownership
+USER root
+RUN chown -R www-data:www-data /var/www/html
+USER www-data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,16 @@
 # Stage 1: PHP Dependencies
-FROM composer:latest AS vendor
+FROM php:8.2-cli AS vendor
+
+# Install system dependencies for composer and common extensions
+RUN apt-get update && apt-get install -y \
+    git \
+    unzip \
+    libzip-dev \
+    libicu-dev \
+    && docker-php-ext-install zip intl pdo_mysql
+
 WORKDIR /var/www/html
+COPY --from=composer:2.7 /usr/bin/composer /usr/bin/composer
 COPY composer.json composer.lock ./
 RUN composer install \
     --no-dev \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,36 @@
+# Use PHP 8.2 FPM (FastCGI Process Manager)
+FROM php:8.2-fpm
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    libpng-dev \
+    libonig-dev \
+    libxml2-dev \
+    zip \
+    unzip \
+    nodejs \
+    npm
+
+# Clear cache
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install PHP extensions required by Laravel
+RUN docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath gd
+
+# Get latest Composer
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+# Set working directory
+WORKDIR /var/www
+
+# Copy entrypoint script
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Use entrypoint script
+ENTRYPOINT ["entrypoint.sh"]
+
+# Default command
+CMD ["php-fpm"]

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -12,7 +12,7 @@ class TrustProxies extends Middleware
      *
      * @var array<int, string>|string|null
      */
-    protected $proxies;
+    protected $proxies = '*';
 
     /**
      * The headers that should be used to detect proxies.

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,67 +1,69 @@
 services:
-    # 1. The PHP Application
-    app:
-        build:
-            context: .
-            dockerfile: Dockerfile.dev
-        container_name: nexus_app
-        restart: unless-stopped
-        working_dir: /var/www
-        volumes:
-            - ./:/var/www:z
-        networks:
-            - nexus-network
-        ports:
-            - "5173:5173"
+  # 1. The PHP Application
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    container_name: nexus_app
+    restart: unless-stopped
+    working_dir: /var/www
+    volumes:
+      - ./:/var/www:z
+    networks:
+      - nexus-network
+    environment:
+      - DB_HOST=db
+    ports:
+      - "5173:5173"
 
-    # 2. The Web Server (Nginx)
-    nginx:
-        image: nginx:alpine
-        container_name: nexus_nginx
-        restart: unless-stopped
-        ports:
-            - "8000:80"
-        volumes:
-            - ./:/var/www:z
-            - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf
-        depends_on:
-            - app
-        networks:
-            - nexus-network
+  # 2. The Web Server (Nginx)
+  nginx:
+    image: nginx:alpine
+    container_name: nexus_nginx
+    restart: unless-stopped
+    ports:
+      - "8000:80"
+    volumes:
+      - ./:/var/www:z
+      - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      - app
+    networks:
+      - nexus-network
 
-    # 3. The Database
-    db:
-        image: mysql:8.0
-        container_name: nexus_db
-        restart: unless-stopped
-        environment:
-            MYSQL_DATABASE: ${DB_DATABASE}
-            MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
-            MYSQL_ALLOW_EMPTY_PASSWORD: 1
-        volumes:
-            - dbdata:/var/lib/mysql
-        networks:
-            - nexus-network
+  # 3. The Database
+  db:
+    image: mysql:8.0
+    container_name: nexus_db
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: ${DB_DATABASE}
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+      MYSQL_ALLOW_EMPTY_PASSWORD: 1
+    volumes:
+      - dbdata:/var/lib/mysql
+    networks:
+      - nexus-network
 
-    # 4. Meilisearch
-    meilisearch:
-        image: "getmeili/meilisearch:latest"
-        container_name: nexus_meilisearch
-        ports:
-            - "7700:7700"
-        volumes:
-            - "meilisearch-data:/meili_data"
-        networks:
-            - nexus-network
-        environment:
-            MEILI_MASTER_KEY: ${MEILISEARCH_KEY:-masterKey}
-            MEILI_NO_ANALYTICS: "true"
-        restart: unless-stopped
+  # 4. Meilisearch
+  meilisearch:
+    image: "getmeili/meilisearch:latest"
+    container_name: nexus_meilisearch
+    ports:
+      - "7700:7700"
+    volumes:
+      - "meilisearch-data:/meili_data"
+    networks:
+      - nexus-network
+    environment:
+      MEILI_MASTER_KEY: ${MEILISEARCH_KEY:-masterKey}
+      MEILI_NO_ANALYTICS: "true"
+    restart: unless-stopped
 
 networks:
-    nexus-network:
-        driver: bridge
+  nexus-network:
+    driver: bridge
 
 volumes:
-    dbdata:
-    meilisearch-data:
+  dbdata:
+  meilisearch-data:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -3,7 +3,7 @@ services:
     app:
         build:
             context: .
-            dockerfile: Dockerfile
+            dockerfile: Dockerfile.dev
         container_name: nexus_app
         restart: unless-stopped
         working_dir: /var/www
@@ -37,8 +37,6 @@ services:
         environment:
             MYSQL_DATABASE: ${DB_DATABASE}
             MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
-            MYSQL_PASSWORD: ${DB_PASSWORD}
-            MYSQL_USER: ${DB_USERNAME}
             MYSQL_ALLOW_EMPTY_PASSWORD: 1
         volumes:
             - dbdata:/var/lib/mysql

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -60,20 +60,6 @@ services:
             MEILI_NO_ANALYTICS: "true"
         restart: unless-stopped
 
-    # 5. Playwright E2E Testing
-    playwright:
-        image: mcr.microsoft.com/playwright:v1.59.1-jammy
-        container_name: nexus_playwright
-        volumes:
-            - ./:/var/www:z
-        working_dir: /var/www
-        ports:
-            - "8060:8060"
-        networks:
-            - nexus-network
-        depends_on:
-            - nginx
-
 networks:
     nexus-network:
         driver: bridge

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,83 @@
+services:
+    # 1. The PHP Application
+    app:
+        build:
+            context: .
+            dockerfile: Dockerfile
+        container_name: nexus_app
+        restart: unless-stopped
+        working_dir: /var/www
+        volumes:
+            - ./:/var/www:z
+        networks:
+            - nexus-network
+        ports:
+            - "5173:5173"
+
+    # 2. The Web Server (Nginx)
+    nginx:
+        image: nginx:alpine
+        container_name: nexus_nginx
+        restart: unless-stopped
+        ports:
+            - "8000:80"
+        volumes:
+            - ./:/var/www:z
+            - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf
+        depends_on:
+            - app
+        networks:
+            - nexus-network
+
+    # 3. The Database
+    db:
+        image: mysql:8.0
+        container_name: nexus_db
+        restart: unless-stopped
+        environment:
+            MYSQL_DATABASE: ${DB_DATABASE}
+            MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+            MYSQL_PASSWORD: ${DB_PASSWORD}
+            MYSQL_USER: ${DB_USERNAME}
+            MYSQL_ALLOW_EMPTY_PASSWORD: 1
+        volumes:
+            - dbdata:/var/lib/mysql
+        networks:
+            - nexus-network
+
+    # 4. Meilisearch
+    meilisearch:
+        image: "getmeili/meilisearch:latest"
+        container_name: nexus_meilisearch
+        ports:
+            - "7700:7700"
+        volumes:
+            - "meilisearch-data:/meili_data"
+        networks:
+            - nexus-network
+        environment:
+            MEILI_MASTER_KEY: ${MEILISEARCH_KEY:-masterKey}
+            MEILI_NO_ANALYTICS: "true"
+        restart: unless-stopped
+
+    # 5. Playwright E2E Testing
+    playwright:
+        image: mcr.microsoft.com/playwright:v1.59.1-jammy
+        container_name: nexus_playwright
+        volumes:
+            - ./:/var/www:z
+        working_dir: /var/www
+        ports:
+            - "8060:8060"
+        networks:
+            - nexus-network
+        depends_on:
+            - nginx
+
+networks:
+    nexus-network:
+        driver: bridge
+
+volumes:
+    dbdata:
+    meilisearch-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,9 @@ services:
             dockerfile: Dockerfile
         command: ["php", "artisan", "queue:work"]
         restart: unless-stopped
+        depends_on:
+            web:
+                condition: service_healthy
         networks:
             - nexus-network
 
@@ -32,6 +35,9 @@ services:
             dockerfile: Dockerfile
         command: ["php", "artisan", "schedule:work"]
         restart: unless-stopped
+        depends_on:
+            web:
+                condition: service_healthy
         networks:
             - nexus-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         networks:
             - nexus-network
         healthcheck:
-            test: ["CMD", "curl", "-f", "http://localhost:8080/up"]
+            test: ["CMD", "curl", "-f", "http://127.0.0.1:8080/up"]
             interval: 30s
             timeout: 10s
             retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
             context: .
             dockerfile: Dockerfile
         restart: unless-stopped
+        environment:
+            - AUTORUN_LARAVEL_MIGRATION=true
         networks:
             - nexus-network
         healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         networks:
             - nexus-network
         healthcheck:
-            test: ["CMD", "curl", "-f", "http://localhost/up"]
+            test: ["CMD", "curl", "-f", "http://localhost:8080/up"]
             interval: 30s
             timeout: 10s
             retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,83 +1,53 @@
 services:
-    # 1. The PHP Application
-    app:
+    # Web Application (PHP + Nginx)
+    web:
         build:
             context: .
             dockerfile: Dockerfile
-        container_name: nexus_app
         restart: unless-stopped
-        working_dir: /var/www
-        volumes:
-            - ./:/var/www:z
         networks:
             - nexus-network
-        ports:
-            - "5173:5173"
+        healthcheck:
+            test: ["CMD", "curl", "-f", "http://localhost/up"]
+            interval: 30s
+            timeout: 10s
+            retries: 3
 
-    # 2. The Web Server (Nginx)
-    nginx:
-        image: nginx:alpine
-        container_name: nexus_nginx
+    # Queue Worker
+    worker:
+        build:
+            context: .
+            dockerfile: Dockerfile
+        command: ["php", "artisan", "queue:work"]
         restart: unless-stopped
-        ports:
-            - "8000:80"
-        volumes:
-            - ./:/var/www:z
-            - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf
-        depends_on:
-            - app
         networks:
             - nexus-network
 
-    # 3. The Database
-    db:
-        image: mysql:8.0
-        container_name: nexus_db
+    # Scheduler
+    scheduler:
+        build:
+            context: .
+            dockerfile: Dockerfile
+        command: ["php", "artisan", "schedule:work"]
         restart: unless-stopped
-        environment:
-            MYSQL_DATABASE: ${DB_DATABASE}
-            MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
-            MYSQL_PASSWORD: ${DB_PASSWORD}
-            MYSQL_USER: ${DB_USERNAME}
-            MYSQL_ALLOW_EMPTY_PASSWORD: 1
-        volumes:
-            - dbdata:/var/lib/mysql
         networks:
             - nexus-network
 
-    # 4. Meilisearch
+    # Meilisearch
     meilisearch:
         image: "getmeili/meilisearch:latest"
-        container_name: nexus_meilisearch
-        ports:
-            - "7700:7700"
-        volumes:
-            - "meilisearch-data:/meili_data"
         networks:
             - nexus-network
         environment:
             MEILI_MASTER_KEY: ${MEILISEARCH_KEY:-masterKey}
             MEILI_NO_ANALYTICS: "true"
-        restart: unless-stopped
-
-    # 5. Playwright E2E Testing
-    playwright:
-        image: mcr.microsoft.com/playwright:v1.59.1-jammy
-        container_name: nexus_playwright
         volumes:
-            - ./:/var/www:z
-        working_dir: /var/www
-        ports:
-            - "8060:8060"
-        networks:
-            - nexus-network
-        depends_on:
-            - nginx
+            - "meilisearch-data:/meili_data"
+        restart: unless-stopped
 
 networks:
     nexus-network:
         driver: bridge
 
 volumes:
-    dbdata:
     meilisearch-data:

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,6 +26,10 @@ use Inertia\Inertia;
 |
 */
 
+Route::get('/up', function () {
+    return response()->noContent();
+});
+
 Route::get('/', function () {
     return Inertia::render('LandingPage');
 });


### PR DESCRIPTION
Transition to a production-ready, single unified container architecture optimized for Coolify and Cloudflare.

- Rewrite Dockerfile as a multi-stage production build using serversideup/php:8.2-fpm-nginx.
- Update docker-compose.yml to use the unified web container and add dedicated worker and scheduler services.
- Configure TrustProxies to trust all proxies for Cloudflare and Traefik compatibility.
- Add a /up health check endpoint for container orchestration.