### PR TITLE
fix(test): disable TTY for docker compose exec to support non-interactive hooks

### DIFF
--- a/bin/test-unit.sh
+++ b/bin/test-unit.sh
@@ -21,10 +21,10 @@ echo "🚀 Starting test stack..."
 $COMPOSE up -d --wait --remove-orphans app_test db_test meilisearch_test
 
 echo "📦 Installing Node dependencies..."
-$COMPOSE exec app_test npm install
+$COMPOSE exec -T app_test npm install
 
 echo "🏗️ Building frontend assets..."
-$COMPOSE exec app_test npm run build
+$COMPOSE exec -T app_test npm run build
 
 echo "🧪 Running PHPUnit (unit + feature)..."
-$COMPOSE exec app_test php artisan test --env=testing
+$COMPOSE exec -T app_test php artisan test --env=testing


### PR DESCRIPTION
The unit test script (bin/test-unit.sh) was failing during the push because it tried to allocate a TTY for docker compose exec in a non-interactive environment (the husky pre-push hook). I modified the script to use the -T flag, ensuring it works seamlessly in hooks and CI.