### PR TITLE
fix(infra): remove unsupported query_cache_size for mysql 8.0

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -45,7 +45,6 @@ services:
     command: >
       --innodb-buffer-pool-size=128M
       --innodb-log-buffer-size=16M
-      --query-cache-size=0
       --max-connections=50
       --tmp-table-size=32M
       --max-heap-table-size=32M


### PR DESCRIPTION
Removed the --query-cache-size flag which was fully removed in MySQL 8.0 and prevents the database container from starting.