### PR TITLE
perf(infra): disable performance schema and increase db memory limit

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -41,13 +41,15 @@ services:
   db:
     image: mysql:8.0
     restart: always
-    mem_limit: 512m
+    mem_limit: 768m
     command: >
       --innodb-buffer-pool-size=128M
       --innodb-log-buffer-size=16M
       --max-connections=50
       --tmp-table-size=32M
       --max-heap-table-size=32M
+      --performance-schema=OFF
+      --table-open-cache=400
     environment:
       MYSQL_DATABASE: ${DB_DATABASE}
       MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}


### PR DESCRIPTION
Disabled MySQL performance schema and reduced table open cache to save memory. Increased the db container memory limit to 768MB to provide a safer buffer against OOM kills on small VPS instances.